### PR TITLE
Use the raw Json value for message ids.

### DIFF
--- a/src/util/Rpc.re
+++ b/src/util/Rpc.re
@@ -13,7 +13,7 @@ module J = {
 
 open Infix;
 
-type jsonrpc = Message(float, string, Json.t) | Notification(string, Json.t);
+type jsonrpc = Message(Json.t, string, Json.t) | Notification(string, Json.t);
 
 let readMessage = (log, input) => {
   let clength = input_line(input);
@@ -30,7 +30,7 @@ let readMessage = (log, input) => {
     let json = try (Json.parse(raw)) {
     | Failure(message) => failwith("Unable to parse message " ++ raw ++ " as json: " ++ message)
     };
-    let id = Json.get("id", json) |?> Json.number;
+    let id = Json.get("id", json);
     let method = Json.get("method", json) |?> Json.string |! "method required";
     let params = Json.get("params", json) |! "params required";
     switch id {
@@ -52,7 +52,7 @@ let sendMessage = (log, output, id, result) => {
   open Json;
   open J;
   let content = Json.stringify(o([
-    ("id", Number(id)),
+    ("id", id),
     ("jsonrpc", s("2.0")),
     ("result", result)]));
   log("Sending response " ++ content);
@@ -63,7 +63,7 @@ let sendError = (log, output, id, error) => {
   open Json;
   open J;
   let content = Json.stringify(o([
-    ("id", Number(id)),
+    ("id", id),
     ("jsonrpc", s("2.0")),
     ("error", error)]));
   log("Sending response " ++ content);


### PR DESCRIPTION
The spec allows ids to be either Number or String. Since the server simply
carries this value around so that it can submit it with the response, the
simplest solution seems to be to pass the Json type through unexamined and send
it right back to the client.

Thanks to the magic of type inference, the change is isolated and nearly
trivial.

Closes #5 