### PR TITLE
Do not serve markdown if not supported

### DIFF
--- a/src/analyze/Hover.re
+++ b/src/analyze/Hover.re
@@ -15,10 +15,11 @@ let getHover = (uri, line, character, state) => {
     switch (Definition.locationAtPos((line, character), data)) {
     | None => None
     | Some((loc, expr, defn)) =>
+      let useMarkdown = state.clientCapabilities.hoverMarkdown;
       let typ =
         PrintType.default.expr(PrintType.default, expr)
         |> PrintType.prettyString;
-      let typ = "```\n" ++ typ ++ "\n```";
+      let typ = useMarkdown ? "```\n" ++ typ ++ "\n```" : typ;
       let tooltip =
         switch (State.getResolvedDefinition(uri, defn, data, state)) {
         | None => typ
@@ -30,10 +31,10 @@ let getHover = (uri, line, character, state) => {
             | None => ""
             }
           )
-          ++ "\n\n*"
+          ++ "\n\n" ++ (useMarkdown ? "*" : "")
           ++ (Utils.startsWith(docUri, state.rootUri ++ "/")
           ? Utils.sliceToEnd(docUri, String.length(state.rootUri ++ "/"))
-          : uri) ++ "*"
+          : uri) ++ (useMarkdown ? "*" : "")
         };
       Some((tooltip, loc));
     }

--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -1,3 +1,8 @@
+type clientCapabilities = {
+  hoverMarkdown: bool,
+  completionMarkdown: bool,
+};
+
 type state = {
   rootPath: string,
   rootUri: string,
@@ -23,6 +28,8 @@ type state = {
   lastDefinitions: Hashtbl.t(string, Definition.moduleData),
   documentTimers: Hashtbl.t(string, float),
   compilationFlags: string,
+
+  clientCapabilities: clientCapabilities,
   /* workspace folders... */
 };
 

--- a/src/lsp/Main.re
+++ b/src/lsp/Main.re
@@ -99,6 +99,14 @@ let getInitialState = (params) => {
         }
       });
 
+      let clientCapabilities = Infix.({
+        hoverMarkdown:
+          Json.getPath("capabilities.textDocument.hover.contentFormat", params) |?> Utils.hasMarkdownCap |? true,
+        completionMarkdown:
+          Json.getPath("capabilities.textDocument.completion.completionItem.documentationFormat", params)
+            |?> Utils.hasMarkdownCap |? true,
+      });
+
       {
         rootPath: rootPath,
         rootUri: uri,
@@ -125,7 +133,8 @@ let getInitialState = (params) => {
           ? rootPath /+ "node_modules" /+ "bs-platform/" /+ "vendor" /+ "ocaml" /+ "lib" /+ "ocaml"
           : rootPath /+ "node_modules" /+ "bs-platform" /+ "lib" /+ "ocaml",
           ...dependencyDirectories
-        ] @ localCompiledDirs
+        ] @ localCompiledDirs,
+        clientCapabilities,
         /* docs, */
       }
     };

--- a/src/lsp/MessageHandlers.re
+++ b/src/lsp/MessageHandlers.re
@@ -47,13 +47,14 @@ let handlers: list((string, (state, Json.t) => result((state, Json.t), string)))
           let opens = PartialParser.findOpens(text, offset);
           /* */
           let localData = State.getLastDefinitions(uri, state);
+          let useMarkdown = state.clientCapabilities.completionMarkdown;
           Completions.get(currentModuleName, opens, parts, state, localData, pos) |> List.map(({Completions.kind, uri, label, detail, documentation}) => o([
             ("label", s(label)),
             ("kind", i(Completions.kindToInt(kind))),
             ("detail", Infix.(detail |?>> s |? null)),
-            ("documentation", Infix.((documentation |?>> d => d ++ "\n\n*" ++ (
+            ("documentation", Infix.((documentation |?>> d => d ++ "\n\n" ++ (useMarkdown ? "*" : "") ++ (
               Utils.startsWith(uri, state.rootPath ++ "/") ? Utils.sliceToEnd(uri, String.length(state.rootPath ++ "/")) : uri
-              ) ++ "*") |?>> Protocol.markup |? null)),
+              ) ++ (useMarkdown ? "*" : "")) |?>> Protocol.markup |? null)),
             ("data", switch kind {
               | RootModule(cmt, src) => o([("cmt", s(cmt)), ("src", s(src)), ("name", s(label))])
               | _ => null

--- a/src/util/Utils.re
+++ b/src/util/Utils.re
@@ -87,3 +87,15 @@ let showLocation = ({Location.loc_start, loc_end}) =>
       loc_end.pos_cnum - loc_end.pos_bol
     )
   );
+
+/*
+  returns true if a MarkupKind[] contains "markdown"
+  NOTE: maybe we should also check if "markdown" is first
+*/
+let hasMarkdownCap = (markupKind) => 
+  Infix.(
+    markupKind
+      |> Json.array
+      |?>> List.map(cap => Json.string(cap) |? "")
+      |?>> List.mem("markdown")
+  )


### PR DESCRIPTION
I'm giving a try at #10 

For now it only removes some top-level markdown. Should we also remove the formatting from `MarkdownOfOCamldoc` ?