### PR TITLE
Fix capabilities reporting.

### DIFF
--- a/src/lsp/Main.re
+++ b/src/lsp/Main.re
@@ -39,13 +39,17 @@ let capabilities =
         /* TODO list # as trigger character */
         ("triggerCharacters", l([s(".")]))
       ])),
-      ("signatureHelpProvider", t),
+      ("signatureHelpProvider", o([
+        ("triggerCharacters", l([s("(")]))
+      ])),
       ("definitionProvider", t),
       ("typeDefinitionProvider", t),
       ("referencesProvider", t),
       ("documentSymbolProvider", t),
       /* ("codeActionProvider", t), */
-      ("codeLensProvider", t),
+      ("codeLensProvider", o([
+        ("resolveProvider", t)
+      ])),
       ("documentHighlightProvider", t),
       ("renameProvider", t),
       ("documentRangeFormattingProvider", t),


### PR DESCRIPTION
signatureHelpProvider and codeLensProvider must return sub-objects which detail
their capabilities, not just "t".