### PR TITLE
 Improve support for serving plain text

### DIFF
--- a/src/analyze/Hover.re
+++ b/src/analyze/Hover.re
@@ -15,7 +15,7 @@ let getHover = (uri, line, character, state) => {
     switch (Definition.locationAtPos((line, character), data)) {
     | None => None
     | Some((loc, expr, defn)) =>
-      let useMarkdown = state.clientCapabilities.hoverMarkdown;
+      let useMarkdown = !state.clientNeedsPlainText;
       let typ =
         PrintType.default.expr(PrintType.default, expr)
         |> PrintType.prettyString;

--- a/src/lsp/Main.re
+++ b/src/lsp/Main.re
@@ -107,13 +107,11 @@ let getInitialState = (params) => {
         }
       });
 
-      let clientCapabilities = Infix.(State.{
-        hoverMarkdown:
-          Json.getPath("capabilities.textDocument.hover.contentFormat", params) |?> Protocol.hasMarkdownCap |? true,
-        completionMarkdown:
-          Json.getPath("capabilities.textDocument.completion.completionItem.documentationFormat", params)
-            |?> Protocol.hasMarkdownCap |? true,
-      });
+      /* if client needs plain text in any place, we disable markdown everywhere */
+      let clientNeedsPlainText = ! Infix.(
+          Json.getPath("capabilities.textDocument.hover.contentFormat", params) |?> Protocol.hasMarkdownCap |? true
+          && Json.getPath("capabilities.textDocument.completion.completionItem.documentationFormat", params) |?> Protocol.hasMarkdownCap |? true,
+      );
 
       State.{
         rootPath: rootPath,
@@ -142,7 +140,7 @@ let getInitialState = (params) => {
           : rootPath /+ "node_modules" /+ "bs-platform" /+ "lib" /+ "ocaml",
           ...dependencyDirectories
         ] @ localCompiledDirs,
-        clientCapabilities,
+        clientNeedsPlainText,
         /* docs, */
       }
     };

--- a/src/lsp/Protocol.re
+++ b/src/lsp/Protocol.re
@@ -60,8 +60,8 @@ let posOfLexing = ({Lexing.pos_lnum, pos_cnum, pos_bol}) =>
 
 let tupleOfLexing = ({Lexing.pos_lnum, pos_cnum, pos_bol}) => (pos_lnum - 1, pos_cnum - pos_bol);
 
-let markup = (text) =>
-  Json.Object([("kind", Json.String("markdown")), ("value", Json.String(text))]);
+let contentKind = (useMarkdown, text) =>
+  Json.Object([("kind", Json.String(useMarkdown ? "markdown" : "text")), ("value", Json.String(text))]);
 
 let rangeOfLoc = ({Location.loc_start, loc_end}) =>
   o([("start", posOfLexing(loc_start)), ("end", posOfLexing(loc_end))]);
@@ -141,7 +141,6 @@ let typeKind = (t) =>
 
 /*
   returns true if a MarkupKind[] contains "markdown"
-  NOTE: maybe we should also check if "markdown" is first
 */
 let hasMarkdownCap = (markupKind) =>
   Infix.(


### PR DESCRIPTION
This PR forces plain text everywhere if markdown is not supported (cf [comment](https://github.com/jaredly/reason-language-server/issues/10#issuecomment-396983764)) +  converts markdown & ocamldoc comments to plaintext.

Notes:

- Could not test 100% since I couldn't find a way to make VSCode request plaintext instead of Markdown. The responses look good when hard-coding `clientNeedsPlainText = true` but VSCode is not happy with it (`Unsupported Markup content received. Kind is: text`)
- In some cases the original markdown comments are not properly converted. It seems like `newDocs` is not always called... Is there another place where definitions are cached ?