### PR TITLE
Windows: Use platform helper for getting temporary directory

### DIFF
--- a/src/lsp/Log.re
+++ b/src/lsp/Log.re
@@ -1,7 +1,7 @@
 let out = ref(None);
 
 /* out := Some(open_out("lsp.log")); */
-out := Some(open_out("/tmp/lsp.log"));
+out := Some(open_out(Filename.concat(Filename.get_temp_dir_name(), "lsp.log")));
 
 let setLocation = (location) => {
   switch out^ {


### PR DESCRIPTION
Thanks for all your work on this, @jaredly ! Stoked to try it out 💯 

__Issue:__ Starting the server on Windows fails with this message:
```
E:\reason-language-server [master ≡]> .\lib\bs\native\bin.native.exe
Fatal error: exception Sys_error("/tmp/lsp.log: No such file or directory")
```

__Proposed Fix:__ Use the platform utility `Filename.get_temp_dir_name` for getting the temporary directory - on my windows machine, this returns "C:/users/<username>/AppData/Local/Temp"