### PR TITLE
Avoid revealing output channel for errors from language server

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 const vscode = require("vscode");
-const {LanguageClient} = require("vscode-languageclient");
+const {LanguageClient, RevealOutputChannelOn} = require("vscode-languageclient");
 const path = require('path')
 const fs = require('fs')
 
@@ -52,7 +52,8 @@ function activate(context) {
                 vscode.workspace.createFileSystemWatcher('**/bsconfig.json'),
                 vscode.workspace.createFileSystemWatcher('**/.merlin')
             ]
-        }
+        },
+    	revealOutputChannelOn: RevealOutputChannelOn.Never,
     };
 
     let client = null


### PR DESCRIPTION
This fixes #39.

This is pretty much copy-pasta from https://github.com/Microsoft/vscode-go/commit/0f166fe74c48051c47095272e85de78c1b63e6fd since I can't get the project to build. 