### PR TITLE
Update package.json to make default width 80.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,8 @@
 				},
 				"reason_language_server.format_width": {
 					"type": "number",
-					"description": "Format width (default=80)"
+					"description": "Format width (default=80)",
+					"default": "80"
 				},
 				"reason_language_server.per_value_codelens": {
 					"type": "boolean",


### PR DESCRIPTION
Make format width default to 80.
Fixes https://github.com/jaredly/reason-language-server/issues/90.