### PR TITLE
Minor change, update url to new location

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "IDE"
   ],
   "repository": {
-    "url": "jaredly/language-server",
+    "url": "jaredly/reason-language-server",
     "type": "git"
   },
   "description": "A pure-reason implementation of a language server",


### PR DESCRIPTION
This should fix the links in the vscode marketplace to point to the correct repo