### PR TITLE
Include bs-dev-dependencies when searching for findDependencyFiles

### DIFF
--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -140,7 +140,7 @@ let newBsPackage = (state, rootPath) => {
       [FindFiles.nameSpaceToName(namespace)]
     }
   };
-  Log.log("Depedency dirs " ++ String.concat(" ", dependencyDirectories));
+  Log.log("Dependency dirs " ++ String.concat(" ", dependencyDirectories));
 
   let (flags, opens) = switch buildSystem {
     /* Bsb-native's support for merlin is not dependable */

--- a/src/util/FindFiles.re
+++ b/src/util/FindFiles.re
@@ -197,6 +197,8 @@ let findDependencyFiles = (~debug, ~buildSystem, base, config) => {
     |?> Json.array
     |? []
     |> optMap(Json.string);
+  let devDeps = config |> Json.get("bs-dev-dependencies") |?> Json.array |? [] |> optMap(Json.string);
+  let deps = deps @ devDeps;
   Log.log("Deps " ++ String.concat(", ", deps));
   let depFiles =
     deps


### PR DESCRIPTION
Hi @jaredly,
I've seen that a change has been made recently to fix #67 .
It didn't work for me. From my understanding, the function that gets called to get the dependencies is `findDependencyFiles` and not `getDependencyDirs`.

I tested these changes on a project I have by pointing `reason_language_server.location` and it works.