### PR TITLE
[example-project] add build command “genFlow” to simulate genFlow output

### DIFF
--- a/examples/example-project/genFlowOutput.sh
+++ b/examples/example-project/genFlowOutput.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+THIS_SCRIPT_DIR="$(cd "$( dirname "$0" )" && pwd)"
+FIRST=$(echo $2 | cut -d':' -f1)
+SECOND=$(echo $2 | cut -d':' -f2)
+ADD="Add $FIRST $SECOND"
+WRITE="Write $THIS_SCRIPT_DIR/$FIRST"
+
+echo "  " $ADD
+echo "  " $WRITE

--- a/examples/example-project/package.json
+++ b/examples/example-project/package.json
@@ -4,6 +4,8 @@
   },
   "scripts": {
     "build": "bsb -make-world",
-    "start": "bsb -make-world -w"
+    "start": "bsb -make-world -w",
+    "clean": "bsb -clean-world",
+    "genFlow": "BS_CMT_POST_PROCESS_CMD=$PWD/genFlowOutput.sh bsb -make-world"
   }
 }


### PR DESCRIPTION
Reference: https://github.com/jaredly/reason-language-server/issues/88#issuecomment-415979579.

To simulate `genFlow` output in `example-project`:
```
yarn clean
yarn genFlow
```

Happy to also generate different output if it helps parsing.
