### PR TITLE
Add "show_module_path_on_hover" setting

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -64,6 +64,11 @@
 					"default": true,
 					"description": "Indicate what values have been used from an open"
 				},
+				"reason_language_server.show_module_path_on_hover": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show the module path on hover"
+				},
 				"reason_language_server.reloadOnChange": {
 					"type": "boolean",
 					"default": false,

--- a/examples/example-project/.vscode/settings.json
+++ b/examples/example-project/.vscode/settings.json
@@ -6,5 +6,5 @@
   "reason_language_server.reloadOnChange": true,
   "reason_language_server.per_value_codelens": false,
   "reason_language_server.show_debug_errors": true,
-  //"reason_language_server.show_module_path_on_hover": false,
+  //"reason_language_server.show_module_path_on_hover": false
 }

--- a/examples/example-project/.vscode/settings.json
+++ b/examples/example-project/.vscode/settings.json
@@ -5,5 +5,6 @@
   // "reason_language_server.location": "../lib/bs/native/bin.native.exe",
   "reason_language_server.reloadOnChange": true,
   "reason_language_server.per_value_codelens": false,
-  "reason_language_server.show_debug_errors": true
+  "reason_language_server.show_debug_errors": true,
+  //"reason_language_server.show_module_path_on_hover": false,
 }

--- a/src/analyze/Hover.re
+++ b/src/analyze/Hover.re
@@ -49,7 +49,7 @@ let showModule = (~markdown, ~file: SharedTypes.file, ~name, declared: option(Sh
 };
 
 open Infix;
-let newHover = (~rootUri, ~file: SharedTypes.file, ~extra, ~getModule, ~markdown, loc) => {
+let newHover = (~rootUri, ~file: SharedTypes.file, ~extra, ~getModule, ~markdown, ~showPath, loc) => {
   switch (loc) {
     | SharedTypes.Loc.Explanation(text) => Some(text)
     /* TODO store a "defined" for Open (the module) */
@@ -126,7 +126,7 @@ let newHover = (~rootUri, ~file: SharedTypes.file, ~extra, ~getModule, ~markdown
 
         let parts = switch (res) {
           | `Declared => {
-            [Some(typeString), docstring, Some(uri)]
+            [Some(typeString), docstring]
           }
           | `Constructor({name: {txt}, args, res}) => {
             [Some(typeString),
@@ -136,17 +136,18 @@ let newHover = (~rootUri, ~file: SharedTypes.file, ~extra, ~getModule, ~markdown
               typeString
 
             }) |> String.concat(", ")) ++ ")")),
-            docstring,
-            Some(uri)]
+            docstring]
           }
           | `Attribute({SharedTypes.Type.Attribute.name: {txt}, typ}) => {
-            [Some(typeString), docstring, Some(uri)]
+            [Some(typeString), docstring]
           }
         };
+
+        let parts = showPath ? parts @ [Some(uri)] : parts;
 
         Some(String.concat("\n\n", parts |. Belt.List.keepMap(x => x)))
       } |? typeString)
 
     }
   };
-}; 
+};

--- a/src/analyze/TopTypes.re
+++ b/src/analyze/TopTypes.re
@@ -42,6 +42,7 @@ type settings = {
   dependenciesCodelens: bool,
   clientNeedsPlainText: bool,
   crossFileAsYouType: bool,
+  showModulePathOnHover: bool,
 };
 
 type state = {
@@ -84,5 +85,6 @@ let empty = () => {
     opensCodelens: true,
     dependenciesCodelens: true,
     clientNeedsPlainText: false,
+    showModulePathOnHover: true,
   },
 };

--- a/src/lsp/MessageHandlers.re
+++ b/src/lsp/MessageHandlers.re
@@ -84,6 +84,7 @@ let handlers: list((string, (state, Json.t) => result((state, Json.t), string)))
               ~extra,
               ~getModule=State.fileForModule(state, ~package),
               ~markdown=! state.settings.clientNeedsPlainText,
+              ~showPath=state.settings.showModulePathOnHover,
               loc,
             );
           Some((typ, hoverText));
@@ -386,6 +387,7 @@ let handlers: list((string, (state, Json.t) => result((state, Json.t), string)))
         ~extra,
         ~getModule=State.fileForModule(state, ~package),
         ~markdown=!state.settings.clientNeedsPlainText,
+        ~showPath=state.settings.showModulePathOnHover,
         loc
       );
 

--- a/src/lsp/NotificationHandlers.re
+++ b/src/lsp/NotificationHandlers.re
@@ -85,6 +85,7 @@ let notificationHandlers: list((string, (state, Json.t) => result(state, string)
     /* let crossFileAsYouType = (settings |?> Json.get("cross_file_as_you_type") |?> Json.bool) |? false; */
     /* Disabling this -- too finnicky :/ */
     let crossFileAsYouType = false;
+    let showModulePathOnHover = (settings |?> Json.get("show_module_path_on_hover") |?> Json.bool) |? true;
     Ok({
       ...state,
       settings: {
@@ -96,6 +97,7 @@ let notificationHandlers: list((string, (state, Json.t) => result(state, string)
         formatWidth,
         dependenciesCodelens,
         crossFileAsYouType,
+        showModulePathOnHover,
       },
     });
   }),


### PR DESCRIPTION
Fixes #134.

Test plan:

You can test it in the default debug environment by uncommenting the line

```
  //"reason_language_server.show_module_path_on_hover": false,
```

in `.vscode/settings.json`.