### PR TITLE
Changes for better support for bsb-native 4.0.6

### DIFF
--- a/src/analyze/BuildSystem.re
+++ b/src/analyze/BuildSystem.re
@@ -40,9 +40,18 @@ let getBsPlatformDir = rootPath => {
   | Some(path) =>
     RResult.Ok(path);
   | None =>
-    let message = "bs-platform could not be found";
-    Log.log(message);
-    RResult.Error(message);
+    let resultSecondary =
+      ModuleResolution.resolveNodeModulePath(
+        ~startPath=rootPath,
+        "bsb-native",
+      );
+    switch (resultSecondary) {
+    | Some(path) => RResult.Ok(path)
+    | None => 
+      let message = "bs-platform could not be found";
+      Log.log(message);
+      RResult.Error(message);
+    }
   };
 };
 

--- a/src/analyze/BuildSystem.re
+++ b/src/analyze/BuildSystem.re
@@ -154,6 +154,9 @@ let getRefmt = (rootPath, buildSystem) => {
     | Bsb(version) when version > "2.2.0" =>
       let%try_wrap bsPlatformDir = getBsPlatformDir(rootPath);
       bsPlatformDir /+ "lib" /+ "refmt.exe"
+    | BsbNative(version, _) when version >= "4.0.6" =>
+      let%try_wrap bsPlatformDir = getBsPlatformDir(rootPath);
+      bsPlatformDir /+ "lib" /+ "refmt.exe"
     | Bsb(_) | BsbNative(_, _) =>
       let%try_wrap bsPlatformDir = getBsPlatformDir(rootPath);
       bsPlatformDir /+ "lib" /+ "refmt3.exe"


### PR DESCRIPTION
Bsb-native 4.0.6 is coming up and it contains one fundamental breaking change: its package name will now be `bsb-native` (instead of `bs-platform`). This will allow me to make npm releases and have proper versioning.
I update this to support that package name as a fallback when not finding `bs-platform`.
I also fix a `refmt` naming issue in the new version.