### PR TITLE
Support reading from .merlin for -backend flag

### DIFF
--- a/src/analyze/BuildSystem.re
+++ b/src/analyze/BuildSystem.re
@@ -93,8 +93,6 @@ let detect = (rootPath, bsconfig) => {
   let%try_wrap backend = switch (backendString) {
   | "js" => Ok(Js)
   | "bytecode" => Ok(Bytecode)
-  
-  
   | "native" => Ok(Native)
   | s => Error("Found unsupported backend: " ++ s);
   };

--- a/src/analyze/BuildSystem.re
+++ b/src/analyze/BuildSystem.re
@@ -89,7 +89,7 @@ let detect = (rootPath, bsconfig) => {
     } : Error("Could not run bsb (ran " ++ cmd ++ "). Output: " ++ String.concat("\n", output));
   };
 
-  let%try backendString = Files.readMerlinFile(rootPath);
+  let%try backendString = MerlinFile.getBackend(rootPath);
   let%try_wrap backend = switch (backendString) {
   | "js" => Ok(Js)
   | "bytecode" => Ok(Bytecode)

--- a/util/Files.re
+++ b/util/Files.re
@@ -248,3 +248,30 @@ let rec collect = (~checkDir=x => true, path, test) =>
     }
   | _ => test(path) ? [path] : []
   };
+
+let readMerlinFile = (path) => {
+  switch (maybeStat(path)) {
+  | Some({Unix.st_kind: Unix.S_REG}) =>
+    let ic = open_in(path);
+    let rec loop = () =>
+      switch (input_line(ic)) {
+      | exception End_of_file => 
+        close_in(ic);
+        RResult.Ok("js")
+      | s => 
+        if (s == "####{BSB GENERATED: NO EDIT") {
+          switch(input_line(ic)) {
+            | exception End_of_file => RResult.Error("Bsb merlin comment not ended correctly");
+            | backendLine => 
+            let len = String.length("# -backend ");
+            let totalLen = String.length(backendLine);
+            RResult.Ok(String.sub(backendLine, len, totalLen - len))
+          }
+        } else {
+          loop()
+        }
+      };
+    loop()
+  | _ => RResult.Ok("js")
+  }
+}

--- a/util/Files.re
+++ b/util/Files.re
@@ -248,30 +248,3 @@ let rec collect = (~checkDir=x => true, path, test) =>
     }
   | _ => test(path) ? [path] : []
   };
-
-let readMerlinFile = (path) => {
-  switch (maybeStat(path)) {
-  | Some({Unix.st_kind: Unix.S_REG}) =>
-    let ic = open_in(path);
-    let rec loop = () =>
-      switch (input_line(ic)) {
-      | exception End_of_file => 
-        close_in(ic);
-        RResult.Ok("js")
-      | s => 
-        if (s == "####{BSB GENERATED: NO EDIT") {
-          switch(input_line(ic)) {
-            | exception End_of_file => RResult.Error("Bsb merlin comment not ended correctly");
-            | backendLine => 
-            let len = String.length("# -backend ");
-            let totalLen = String.length(backendLine);
-            RResult.Ok(String.sub(backendLine, len, totalLen - len))
-          }
-        } else {
-          loop()
-        }
-      };
-    loop()
-  | _ => RResult.Ok("js")
-  }
-}


### PR DESCRIPTION
Partially fixes #84.

This will make reason-language-server probably report that it couldn't find any built artifacts for any files that are guarded to being built only for, say, web, and you're currently building to byte code.

We can fix that in another PR but it'll be trickier. Even if we We'll have to read the bsconfig and figure out what folder the current file is in, then make RLS call bsb with the appropriate backend flag, that won't get the dependencies compiled to the right target. Maybe we should error and tell the user "Hey this is a X-only file, go and build your project to that target".