### PR TITLE
Enable comment syntax highlighting in jsx attributes

### DIFF
--- a/editor-extensions/vscode/reason.json
+++ b/editor-extensions/vscode/reason.json
@@ -221,7 +221,8 @@
           ]
         },
         { "include": "#jsx-attributes" },
-        { "include": "#jsx-body" }
+        { "include": "#jsx-body" },
+        { "include": "#comment" }
       ]
     },
     "jsx-tail": {


### PR DESCRIPTION
This allows proper syntax highlighting of comment blocks `/* comment */` of JSX attributes in Reason files.