### PR TITLE
Show proper name for dune when encounter error

### DIFF
--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -11,7 +11,7 @@ module Show = {
       Printf.sprintf("%s (%s : %s)", name, SharedTypes.getCmt(paths), SharedTypes.getSrc(paths) |? "(no src!)")
     }) |> String.concat("\n"))
     ++
-    "\nDeps\n" ++ 
+    "\nDeps\n" ++
     (Belt.List.map(dependencyModules, (modname) => {
       let paths = Hashtbl.find(pathsForModule, modname);
       Printf.sprintf("%s (%s : %s)", modname, SharedTypes.getCmt(paths), SharedTypes.getSrc(paths) |? "")
@@ -153,7 +153,7 @@ let newBsPackage = (~reportDiagnostics, state, rootPath) => {
       | _ => Log.log("Both")
     }
   });
-  
+
   let (pathsForModule, nameForPath) = makePathsForModule(localModules, dependencyModules);
 
   let opens = switch (namespace) {
@@ -253,7 +253,7 @@ let newBsPackage = (~reportDiagnostics, state, rootPath) => {
     compilerVersion: BuildSystem.V402,
     compilationFlags: flags |> String.concat(" "),
     interModuleDependencies,
-    includeDirectories: 
+    includeDirectories:
       localCompiledDirs @
       dependencyDirectories @
       stdLibDirectories
@@ -283,7 +283,7 @@ let newJbuilderPackage = (~reportDiagnostics, state, rootPath) => {
 
   let buildSystem = BuildSystem.Dune;
 
-  let%try jbuildRaw = JbuildFile.readFromDir(rootPath);
+  let%try (jbuildPath, jbuildRaw) = JbuildFile.readFromDir(rootPath);
   let%try jbuildConfig = switch (JbuildFile.parse(jbuildRaw)) {
     | exception Failure(message) => Error("Unable to parse build file " ++ rootPath /+ "jbuild " ++ message)
     | x => Ok(x)
@@ -343,7 +343,7 @@ let newJbuilderPackage = (~reportDiagnostics, state, rootPath) => {
   let (otherDirectories, otherFiles) = source |> List.filter(s => s != "." && s != "" && s.[0] == '.') |> optMap(name => {
     let otherPath = rootPath /+ name;
     let res = {
-      let%try jbuildRaw = JbuildFile.readFromDir(otherPath);
+      let%try (jbuildPath, jbuildRaw) = JbuildFile.readFromDir(otherPath);
       let%try jbuildConfig = switch (JbuildFile.parse(jbuildRaw)) {
         | exception Failure(message) => Error("Unable to parse build file " ++ rootPath /+ "jbuild " ++ message)
         | x => Ok(x)
@@ -818,7 +818,7 @@ let getCompilationResult = (uri, state, ~package: TopTypes.package) => {
 
 let getLastDefinitions = (uri, state) => switch (Hashtbl.find(state.lastDefinitions, uri)) {
 | exception Not_found => None
-| data => 
+| data =>
   Some(data)
 };
 

--- a/util/JbuildFile.re
+++ b/util/JbuildFile.re
@@ -192,9 +192,14 @@ let parse = raw => {
 };
 
 let readFromDir = (dirPath) => {
-  let jbuildRaw = switch (Files.readFileResult(dirPath /+ "dune")) {
-  | Ok(x) => Ok(x)
-  | Error(_) => Files.readFileResult(dirPath /+ "jbuild")
+  let filePath = dirPath /+ "dune";
+  switch (Files.readFileResult(filePath)) {
+  | Ok(x) => Ok((filePath, x))
+  | Error(_) =>
+    let filePath = dirPath /+ "jbuild";
+    switch (Files.readFileResult(filePath)) {
+    | Ok(x) => Ok((filePath, x))
+    | Error(x) => Error(x)
+    }
   };
-  jbuildRaw
 };


### PR DESCRIPTION
When extension encounters an error in dune it still shows that it happened in jbuilder.
```
Unable to parse build file /Users/s/src/oneserve/src/jbuild Unexpected char: / at 51
```
This PR aims to fix it.