### PR TITLE
Show types for module members

### DIFF
--- a/src/lsp/MessageHandlers.re
+++ b/src/lsp/MessageHandlers.re
@@ -329,7 +329,8 @@ let handlers: list((string, (state, Json.t) => result((state, Json.t), string)))
       };
 
       let getLensItems = ({SharedTypes.file, extra}) => {
-        /* getLensTopLevel gives the list */
+        /* getTypeLensTopLevel gives the list of per-value type codeLens
+           for every value in a module topLevel */
         let rec getTypeLensTopLevel = (topLevel) => {
           switch (topLevel) {
               | [] => []


### PR DESCRIPTION
Fix #139 
fix the getLensItems function to retrieve type codeLens on value that are nested in a module