### PR TITLE
Fix esy version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ I had a couple of reasons for starting a new one. The biggest is that I wanted s
 
 ## Contributing
 
-- Install `esy` if you don't have it (`npm install -g esy@next`)
+- Install `esy` if you don't have it (`npm install -g esy`)
 - Clone this repo
 - `cd` to the cloned dir
 - Run `esy` from the main project dir


### PR DESCRIPTION
Current version of `esy` is `0.3.4`, "next" is stuck at `0.3.1`. Maybe it is better to drop `@next`?