### PR TITLE
Disable formatOnSave for reason

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.formatOnSave": false,
+  "[reason]": {
+    "editor.formatOnSave": true
+  },
   "git.ignoreLimitWarning": true,
   "git.enabled": true,
   "editor.codeLens": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": false,
   "[reason]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": false
   },
   "git.ignoreLimitWarning": true,
   "git.enabled": true,


### PR DESCRIPTION
Some people (like me) don't use `formatOnSave` by default but specify it for particular syntaxes. In that case, global `formatOnSave` will not work, so I need to disable it specifically for reason syntax.