### PR TITLE
Remove esy version detection

### DIFF
--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -426,7 +426,7 @@ let newJbuilderPackage = (~reportDiagnostics, state, rootPath) => {
   let interModuleDependencies = Hashtbl.create(List.length(localModules));
 
   let buildCommand = switch (pkgMgr) {
-    | Esy(_) =>
+    | Esy =>
       Some(("esy", projectRoot))
     | Opam(switchPrefix) =>
       if (Files.exists(switchPrefix /+ "bin" /+ "dune")) {

--- a/src/analyze_fixture_tests/lib/TestUtils.re
+++ b/src/analyze_fixture_tests/lib/TestUtils.re
@@ -3,7 +3,7 @@ let tmp = "/tmp/.lsp-test";
 Files.mkdirp(tmp);
 
 let getPackage = (localModules) => {
-  let buildSystem = BuildSystem.Dune(Esy("0.3.4"));
+  let buildSystem = BuildSystem.Dune(Esy);
   let%try refmtPath = BuildSystem.getRefmt(".", buildSystem);
   let%try_wrap compilerPath = BuildSystem.getCompiler(".", buildSystem);
   let (pathsForModule, nameForPath) = State.makePathsForModule(localModules, []);


### PR DESCRIPTION
We now do things in a way that's compatible across every esy version.
This is just introducing unnecessary complexity.