### PR TITLE
Disable autoRebuild inside Esy named sandboxes

### DIFF
--- a/src/analyze/BuildSystem.re
+++ b/src/analyze/BuildSystem.re
@@ -228,13 +228,17 @@ let getStdlib = (base, buildSystem) => {
   };
 };
 
-let getExecutableInEsyPath = (exeName, ~pwd) => {
-  let env = Unix.environment()->Array.to_list;
+let isRunningInEsyNamedSandbox = () => {
   /* Check if we have `cur__target_dir` as a marker that we're inside an Esy context */
-  switch (Utils.getEnvVar(~env, "cur__target_dir")) {
-  | Some(_) => getLine("which " ++ exeName, ~pwd)
-  | None => getLine("esy which " ++ exeName, ~pwd)
-  };
+  Belt.Option.isSome(Utils.getEnvVar("cur__target_dir"))
+};
+
+let getExecutableInEsyPath = (exeName, ~pwd) => {
+  if (isRunningInEsyNamedSandbox()) {
+    getLine("which " ++ exeName, ~pwd)
+  } else {
+    getLine("esy which " ++ exeName, ~pwd)
+  }
 };
 
 let getCompiler = (rootPath, buildSystem) => {

--- a/src/lsp/Main.re
+++ b/src/lsp/Main.re
@@ -95,29 +95,28 @@ let getInitialState = (params) => {
       && Json.getPath("capabilities.textDocument.completion.completionItem.documentationFormat", params) |?> Protocol.hasMarkdownCap |? true,
   );
 
-  /* Check if we have `cur__target_dir` as a marker that we're inside an Esy context,
-   * i.e. the editor was started with e.g. `esy @myalias code .`.
+  /* Check the editor was started with e.g. `esy @myalias code .`.
    * We can't support auto rebuild in this case yet because Esy doesn't provide
    * enough information on which named sandbox we're in.
    */
   let state =
-    switch (Utils.getEnvVar("cur__target_dir")) {
-    | Some(_) =>
+    if (BuildSystem.isRunningInEsyNamedSandbox()) {
       let empty = TopTypes.empty();
       {
         ...empty,
         settings: {
           ...empty.settings,
-          autoRebuild: false
+          autoRebuild: false,
         },
         rootPath,
+        rootUri: uri,
+      };
+    } else {
+      {
+        ...TopTypes.empty(),
+        rootPath,
         rootUri: uri
-      }
-    | None => {
-      ...TopTypes.empty(),
-      rootPath,
-      rootUri: uri
-    }
+      };
     };
 
   Ok({...state, settings: {...state.settings, clientNeedsPlainText}})

--- a/src/lsp/Main.re
+++ b/src/lsp/Main.re
@@ -95,11 +95,30 @@ let getInitialState = (params) => {
       && Json.getPath("capabilities.textDocument.completion.completionItem.documentationFormat", params) |?> Protocol.hasMarkdownCap |? true,
   );
 
-  let state = {
-    ...TopTypes.empty(),
-    rootPath,
-    rootUri: uri,
-  };
+  /* Check if we have `cur__target_dir` as a marker that we're inside an Esy context,
+   * i.e. the editor was started with e.g. `esy @myalias code .`.
+   * We can't support auto rebuild in this case yet because Esy doesn't provide
+   * enough information on which named sandbox we're in.
+   */
+  let state =
+    switch (Utils.getEnvVar("cur__target_dir")) {
+    | Some(_) =>
+      let empty = TopTypes.empty();
+      {
+        ...empty,
+        settings: {
+          ...empty.settings,
+          autoRebuild: false
+        },
+        rootPath,
+        rootUri: uri
+      }
+    | None => {
+      ...TopTypes.empty(),
+      rootPath,
+      rootUri: uri
+    }
+    };
 
   Ok({...state, settings: {...state.settings, clientNeedsPlainText}})
 };


### PR DESCRIPTION
Esy doesn't yet tell us which named sandbox we're in. Let's disabled
autoRebuild for this case while we wait for support in Esy proper.

I'm also opening a general issue about RLS in Esy which I'll link here
shortly.