### PR TITLE
[WIP] Windows Support - esy + dune config

### DIFF
--- a/src/analyze/BuildSystem.re
+++ b/src/analyze/BuildSystem.re
@@ -1,3 +1,4 @@
+
 type target =
   | Js
   | Bytecode
@@ -138,34 +139,34 @@ let getEsyCompiledBase = (root) => {
       }
   };
 
-    let prevCwd = Unix.getcwd();
-    Unix.chdir(root);
-    let res = Commands.execResult("esy command-env --json")
-    Unix.chdir(prevCwd);
-        
-    switch (res) {
-    | Ok(commandEnv) =>
-      switch (Json.parse(commandEnv)) {
-      | exception (Failure(message)) =>
-        Log.log("Json response");
-        Log.log(commandEnv);
-        Error("Couldn't find Esy target directory (invalid json response: parse fail): " ++ message);
-      | exception exn =>
-        Log.log(commandEnv);
-        Error("Couldn't find Esy target directory (invalid json response) " ++ Printexc.to_string(exn));
-      | json =>
-        Json.Infix.(
-          switch (
-            Json.get("cur__original_root", json) |?> Json.string,
-            Json.get("cur__target_dir", json) |?> Json.string,
-          ) {
-          | (Some(projectRoot), Some(targetDir)) => Ok(Files.relpath(correctSlashesOnWindows(projectRoot), correctSlashesOnWindows(targetDir)))
-          | _ => Error("Couldn't find Esy target directory (missing json entries)")
-          }
-        )
-      }
-    | err => err
+  let prevCwd = Unix.getcwd();
+  Unix.chdir(root);
+  let res = Commands.execResult("esy command-env --json")
+  Unix.chdir(prevCwd);
+      
+  switch (res) {
+  | Ok(commandEnv) =>
+    switch (Json.parse(commandEnv)) {
+    | exception (Failure(message)) =>
+      Log.log("Json response");
+      Log.log(commandEnv);
+      Error("Couldn't find Esy target directory (invalid json response: parse fail): " ++ message);
+    | exception exn =>
+      Log.log(commandEnv);
+      Error("Couldn't find Esy target directory (invalid json response) " ++ Printexc.to_string(exn));
+    | json =>
+      Json.Infix.(
+        switch (
+          Json.get("cur__original_root", json) |?> Json.string,
+          Json.get("cur__target_dir", json) |?> Json.string,
+        ) {
+        | (Some(projectRoot), Some(targetDir)) => Ok(Files.relpath(correctSlashesOnWindows(projectRoot), correctSlashesOnWindows(targetDir)))
+        | _ => Error("Couldn't find Esy target directory (missing json entries)")
+        }
+      )
     }
+  | err => err
+  }
 };
 
 let getCompiledBase = (root, buildSystem) => {

--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -361,6 +361,8 @@ let newJbuilderPackage = (~reportDiagnostics, state, rootPath) => {
     );
   });
 
+
+  /* print_endline("Getting things"); */
   let (otherDirectories, otherFiles) = source |> List.filter(s => s != "." && s != "" && s.[0] != '/') |> optMap(name => {
     let otherPath = rootPath /+ name;
     let res = {

--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -361,8 +361,6 @@ let newJbuilderPackage = (~reportDiagnostics, state, rootPath) => {
     );
   });
 
-
-  /* print_endline("Getting things"); */
   let (otherDirectories, otherFiles) = source |> List.filter(s => s != "." && s != "" && s.[0] != '/') |> optMap(name => {
     let otherPath = rootPath /+ name;
     let res = {

--- a/src/analyze_example_tests/ExamplesTests.re
+++ b/src/analyze_example_tests/ExamplesTests.re
@@ -32,11 +32,11 @@ let checkExampleProject = (rootPath, sourcePaths) => {
 };
 
 let projects = [
-  /* ("example-project", ["src"], "npm install"), */
-  /* ("example-es6-imports", ["src"], "npm install"), */
-  /* ("example-react", ["src", "__tests__"], "npm install"), */
-  /* ("name_with_underscore", ["src"], "npm install"), */
-  /* ("bs-3.1.5", ["src"], "npm install"), */
+  ("example-project", ["src"], "npm install"),
+  ("example-es6-imports", ["src"], "npm install"),
+  ("example-react", ["src", "__tests__"], "npm install"),
+  ("name_with_underscore", ["src"], "npm install"),
+  ("bs-3.1.5", ["src"], "npm install"),
   ("example-esy-dune-project", ["lib", "bin"], "esy"),
 ];
 

--- a/src/analyze_example_tests/ExamplesTests.re
+++ b/src/analyze_example_tests/ExamplesTests.re
@@ -32,12 +32,12 @@ let checkExampleProject = (rootPath, sourcePaths) => {
 };
 
 let projects = [
-  ("example-project", ["src"], "npm install"),
-  ("example-es6-imports", ["src"], "npm install"),
-  ("example-react", ["src", "__tests__"], "npm install"),
-  ("name_with_underscore", ["src"], "npm install"),
-  ("bs-3.1.5", ["src"], "npm install"),
-  /* ("example-esy-dune-project", ["lib", "bin"], "esy"), */
+  /* ("example-project", ["src"], "npm install"), */
+  /* ("example-es6-imports", ["src"], "npm install"), */
+  /* ("example-react", ["src", "__tests__"], "npm install"), */
+  /* ("name_with_underscore", ["src"], "npm install"), */
+  /* ("bs-3.1.5", ["src"], "npm install"), */
+  ("example-esy-dune-project", ["lib", "bin"], "esy"),
 ];
 
 

--- a/util/Infix.re
+++ b/util/Infix.re
@@ -34,7 +34,7 @@ let logIfAbsent = (message, x) => switch x {
 };
 
 let maybeConcat = (a, b) => {
-  if (b != "" && b.[0] == '/') {
+  if (b != "" && (b.[0] == '/' || b.[1] == ':')) {
     b
   } else {
     fileConcat(a, b)


### PR DESCRIPTION
__Issue:__ `reason-language-server` isn't working for Windows configs. Uncommenting out the test is the quickest way to reproduce this.

There were several issues:
- `esy which` gives a cygwin style path on Windows, so it's not what we want - for those paths, we then run them in the native shell, which will fail. I switched this to using `esy where` on Windows, which works as expected.
- Path concatenation was not working in all cases, because it made assumptions about the form of the root directory - on Windows, a root directory could be something like `E:\` or `C:\`, so added some detection there.

Still a bunch of things to fix - I'll leave comments for some open issues.
