### PR TITLE
vscode: add syntax highlighting for md embed

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -112,6 +112,16 @@
 				"language": "reason_lisp",
 				"scopeName": "source.reason_lisp",
 				"path": "./reason-lisp.json"
+			},
+			{
+				"scopeName": "markdown.reason.codeblock",
+				"path": "./reason-markdown-codeblock.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.reason": "reason"
+				}
 			}
 		],
 		"languages": [

--- a/editor-extensions/vscode/reason-markdown-codeblock.json
+++ b/editor-extensions/vscode/reason-markdown-codeblock.json
@@ -1,0 +1,28 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:markup.fenced_code.block.markdown",
+  "patterns": [
+    {
+      "include": "#reason-code-block"
+    }
+  ],
+  "repository": {
+    "reason-code-block": {
+      "begin": "(reason|reasonml)(\\s+[^`~]*)?$",
+      "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.reason",
+          "patterns": [
+            {
+              "include": "source.reason"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.reason.codeblock"
+}


### PR DESCRIPTION
Adding syntax highlighting for markdown embeds.

**Before...**

<img width="1024" alt="screen shot 2019-01-05 at 7 17 04 am" src="https://user-images.githubusercontent.com/1024544/50725922-843c0c00-10ba-11e9-9210-97584fb19385.png">

**After...**

<img width="1024" alt="screen shot 2019-01-05 at 7 17 29 am" src="https://user-images.githubusercontent.com/1024544/50725919-79817700-10ba-11e9-96a3-ad29fbb67143.png">

