### PR TITLE
Dedupe the source files list.

### DIFF
--- a/src/analyze/FindFiles.re
+++ b/src/analyze/FindFiles.re
@@ -177,6 +177,7 @@ let findProjectFiles = (~debug, namespace, root, sourceDirectories, compiledBase
   |> ifDebug(debug, "Source directories", String.concat(" - "))
   |> List.map(name => Files.collect(name, isSourceFile))
   |> List.concat
+  |> Utils.dedup
   |> ifDebug(debug, "Source files found", String.concat(" : "));
 
   /* |> filterDuplicates


### PR DESCRIPTION
Let's say I have

- `src/dir/X.re`
- `src/dir/X.rei`
- `src/dir/sub/Y.re`
- `src/dir/sub/Y.rei`

`findProjectFiles` would then be fed with `src/dir` and `src/dir/sub`.

`Y.re` & `Y.rei` would appear two times in files.

When iterating over the files to generate normals, an interface is removed from the hashtbl as soon as its implementation file is treated, meaning the first occurence of `Y.re` would be considered to contain an interface, the second one would not.