### PR TITLE
Escape spaces in ppx-flag arguments when passing to bsb

### DIFF
--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -208,7 +208,7 @@ let newBsPackage = (~overrideBuildSystem=?, ~reportDiagnostics, state, rootPath)
       let ppxs = config |> Json.get("ppx-flags") |?> Json.array |?>> Utils.filterMap(Json.string) |? [];
       Log.log("Getting hte ppxs yall");
       let flags = flags @ (Belt.List.map(ppxs, name => {
-        MerlinFile.fixPpx("-ppx " ++ name, rootPath) |> escapePpxFlag
+        MerlinFile.fixPpx("-ppx " ++ Fielname.quote(name), rootPath)
       }));
       let flags = switch (config |> Json.get("warnings") |?> Json.get("number") |?> Json.string) {
         | None => flags

--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -208,7 +208,7 @@ let newBsPackage = (~overrideBuildSystem=?, ~reportDiagnostics, state, rootPath)
       let ppxs = config |> Json.get("ppx-flags") |?> Json.array |?>> Utils.filterMap(Json.string) |? [];
       Log.log("Getting hte ppxs yall");
       let flags = flags @ (Belt.List.map(ppxs, name => {
-        MerlinFile.fixPpx("-ppx " ++ Fielname.quote(name), rootPath)
+        MerlinFile.fixPpx("-ppx " ++ Filename.quote(name), rootPath)
       }));
       let flags = switch (config |> Json.get("warnings") |?> Json.get("number") |?> Json.string) {
         | None => flags

--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -109,6 +109,14 @@ let runBuildCommand = (~reportDiagnostics, state, root, buildCommand) => {
   /* TODO report notifications here */
 };
 
+let escapePpxFlag = flag => {
+  let parts = Utils.split_on_char(' ', flag);
+  switch(parts) {
+    | ["-ppx", ...ppx] => "-ppx " ++ (String.concat(" ", ppx) |> Filename.quote)
+    | _ => flag
+  }
+};
+
 let newBsPackage = (~overrideBuildSystem=?, ~reportDiagnostics, state, rootPath) => {
   let%try raw = Files.readFileResult(rootPath /+ "bsconfig.json");
   let config = Json.parse(raw);
@@ -200,7 +208,7 @@ let newBsPackage = (~overrideBuildSystem=?, ~reportDiagnostics, state, rootPath)
       let ppxs = config |> Json.get("ppx-flags") |?> Json.array |?>> Utils.filterMap(Json.string) |? [];
       Log.log("Getting hte ppxs yall");
       let flags = flags @ (Belt.List.map(ppxs, name => {
-        MerlinFile.fixPpx("-ppx " ++ name, rootPath)
+        MerlinFile.fixPpx("-ppx " ++ name, rootPath) |> escapePpxFlag
       }));
       let flags = switch (config |> Json.get("warnings") |?> Json.get("number") |?> Json.string) {
         | None => flags
@@ -208,10 +216,9 @@ let newBsPackage = (~overrideBuildSystem=?, ~reportDiagnostics, state, rootPath)
       };
       (flags @ [
         "-ppx " ++ bsPlatform /+ "lib" /+ "bsppx.exe"
-
       ], opens)
     | _ => {
-      let flags = MerlinFile.getFlags(rootPath) |> RResult.withDefault([""]);
+      let flags = MerlinFile.getFlags(rootPath) |> RResult.withDefault([""]) |> List.map(escapePpxFlag);
       let opens = List.fold_left((opens, item) => {
         let parts = Utils.split_on_char(' ', item);
         let rec loop = items => switch items {


### PR DESCRIPTION
Escapes every `-ppx` argument passed to `bsb` using apprach used in https://github.com/BuckleScript/bucklescript/pull/2963.

Fixes https://github.com/jaredly/reason-language-server/issues/229