### PR TITLE
Make default format_width value of declared type

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -80,8 +80,8 @@
 				},
 				"reason_language_server.format_width": {
 					"type": "number",
-					"description": "Format width (default=80)",
-					"default": "80"
+					"default": 80,
+					"description": "Format width (default=80)"
 				},
 				"reason_language_server.per_value_codelens": {
 					"type": "boolean",


### PR DESCRIPTION
For some reason, this was a string. Oops!