### PR TITLE
Escape pp-flags arguments when parsing .merlin

### DIFF
--- a/src/analyze/State.re
+++ b/src/analyze/State.re
@@ -117,6 +117,7 @@ let escapePpxFlag = flag => {
     let parts = Utils.split_on_char(' ', flag);
     switch(parts) {
       | ["-ppx", ...ppx] => "-ppx " ++ (String.concat(" ", ppx) |> Filename.quote)
+      | ["-pp", ...pp] => "-pp " ++ (String.concat(" ", pp) |> Filename.quote)
       | _ => flag
     }
   }


### PR DESCRIPTION
Imagine a .merlin containing:
```
FLG -pp /Users/iwan/Development/pp-demo/./node_modules/.bin/napkinscript -ancient
```
`-ancient` shouldn't be picked up as separate compiler flag, but as part of
the napkinscript preprocessor