### PR TITLE
Use NODE_PATH on module resolution

### DIFF
--- a/util/ModuleResolution.re
+++ b/util/ModuleResolution.re
@@ -3,7 +3,18 @@ open Infix;
 let rec resolveNodeModulePath = (~startPath=".", name) => {
   let path = startPath /+ "node_modules" /+ name;
   switch (startPath) {
-  | "/" => Files.exists(path) ? Some(path) : None
+  | "/" => if (Files.exists(path)) {
+      Some(path);
+    } else {
+      switch (Sys.getenv("NODE_PATH")) {
+      | node_path =>
+        node_path
+        |> Str.split(Str.regexp(":"))
+        |> List.map((path) => Filename.concat(path, name))
+        |> List.find_opt((path) => Files.exists(path));
+      | exception Not_found => None
+      };
+    };
   | _ =>
     Files.exists(path) ?
       Some(path) :


### PR DESCRIPTION
Search the `NODE_PATH` environment variable for modules if they are not found elsewhere, [just like Node.js](https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders).

> Note: Currently BuckleScript doesn't support `$NODE_PATH` either, [it checks `"$npm_config_prefix/lib/node_modules"` instead](https://github.com/BuckleScript/bucklescript/blob/5.0.3/jscomp/bsb/bsb_pkg.ml#L51-L52) (which I don't know the reason of doing so). Maybe we should support that too/instead.