### PR TITLE
Update installation instructions for Sublime Text

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,8 +53,15 @@ And you're done!
     "reason": {
       "enabled": true,
       "command": ["/absolute/path/to/reason-language-server.exe"],
-      "scopes": ["source.reason"],
-      "syntaxes": ["Packages/Reason/Reason.tmLanguage"],
+      "scopes": [
+        "source.reason",
+        "source.ocaml"
+      ],
+      "syntaxes": [
+        "Packages/Reason/Reason.tmLanguage",
+        "Packages/sublime-reason/Reason.tmLanguage",
+        "Packages/OCaml/OCaml.sublime-syntax"
+      ],
       "languageId": "reason"
     }
   }


### PR DESCRIPTION
Change the suggested LSP preferences to:

- Enable reason-language-server for .ml files.
- Enable for sublime-reason (the same Reason sublime package is published under two names: Reason and sublime-reason).
