### PR TITLE
Fix erroneous double quoting of pp/ppx flags

### DIFF
--- a/src/analyze/Packages.re
+++ b/src/analyze/Packages.re
@@ -9,8 +9,8 @@ let escapePreprocessingFlags = flag => {
   } else {
     let parts = Utils.split_on_char(' ', flag);
     switch(parts) {
-      | ["-ppx", ...ppx] => "-ppx " ++ (String.concat(" ", ppx) |> Filename.quote)
-      | ["-pp", ...pp] => "-pp " ++ (String.concat(" ", pp) |> Filename.quote)
+      | [("-ppx" | "-pp") as flag, ...rest] =>
+        flag ++ " " ++ Utils.maybeQuoteFilename(String.concat(" ", rest))
       | _ => flag
     }
   }

--- a/util/Utils.re
+++ b/util/Utils.re
@@ -250,3 +250,23 @@ let getEnvVar = (~env=Unix.environment()->Array.to_list, varToFind) => {
     | _ => None
   }
 }
+
+/*
+ * Quotes filename when not quoted
+ * Example:
+ * myFile.exe -> 'myFile.exe'
+ * 'myFile.exe' -> 'myFile.exe'
+ */
+let maybeQuoteFilename = (filename) => {
+  let len = String.length(filename);
+  if (len < 1) {
+    ""
+  } else {
+    let firstChar = String.get(filename, 0);
+    let lastChar = String.get(filename, len - 1)
+    switch (firstChar, lastChar) {
+    | ('\'','\'') => filename
+    | _ => Filename.quote(filename)
+    }
+  }
+}


### PR DESCRIPTION
Problem:
```
# example merlin file
FLG -ppx '/Users/Foo/Bar/my-react-app/node_modules/bs-platform/lib/bsppx.exe -bs-jsx 3'
```
The ppx executable with flag is fully quoted in this case (standard shell conventions).
RLS shouldn't try to double quote already quoted filenames

Fixes https://github.com/jaredly/reason-language-server/issues/275

