### PR TITLE
Fix vscode comments highlight with // inside block comment

### DIFF
--- a/editor-extensions/vscode/reason.json
+++ b/editor-extensions/vscode/reason.json
@@ -108,19 +108,15 @@
     "comment-line": {
       "name": "comment.line",
       "begin": "(^[ \\t]+)?((//))",
-      "end": "(?=^)",
-      "patterns": [
-        {
-          "include": "#comment"
-        }
-      ]
+      "end": "(?=^)"
     },
     "comment-block": {
       "begin": "/\\*",
       "end": "\\*/",
       "name": "comment.block",
       "patterns": [
-        { "include": "#comment" }
+        { "include": "#comment-block-doc" },
+        { "include": "#comment-block" }
       ]
     },
     "comment-block-doc": {
@@ -128,7 +124,8 @@
       "end": "\\*/",
       "name": "comment.block.documentation",
       "patterns": [
-        { "include": "#comment" }
+        { "include": "#comment-block-doc" },
+        { "include": "#comment-block" }
       ]
     },
     "condition-lhs": {


### PR DESCRIPTION
Fix for this https://github.com/jaredly/reason-language-server/issues/241
Allow to use double slashes in block comments.

This example should work fine now
```
let maxExp = 2145916800 |> Int64.of_int;/* 1 Jan 2038 year timestamp https://en.wikipedia.org/wiki/Year_2038_problem */
```

This is my first change in vscode extention, so I am not sure I not breaking anything