### PR TITLE
Don't apply other preprocessing flags to Reason files.

### DIFF
--- a/src/analyze/AsYouType.re
+++ b/src/analyze/AsYouType.re
@@ -124,6 +124,19 @@ let parseDependencyError = text => {
 };
 
 let justBscCommand = (~interface, ~reasonFormat, ~command, compilerPath, sourceFile, includes, flags) => {
+  let flags = reasonFormat ? {
+    /* Filter out -pp flags for Reason files. Refmt is the only preprocessor
+       that should apply to Reason files. */
+    let parts = Utils.split_on_char(' ', flags);
+    let rec loop = (items) => {
+      switch(items) {
+        | ["-pp", _ppFlag, ...rest] => loop(rest)
+        | [x, ...rest] => [x, ...loop(rest)]
+        | [] => []
+      }
+    };
+    loop(parts) |> String.concat(" ")
+  } : flags;
   /* TODO make sure that bsc supports -color */
   Printf.sprintf(
     {|%s %s %s -bin-annot %s %s %s|},


### PR DESCRIPTION
Refmt is the only pp that should be applied to Reason files.
If a bsconfig contains "pp-flags", they shouldn't be applied to .re files.
Refmt is the source of truth. Follows the behaviour of Bucklescript itself.