### PR TITLE
Fix locations for complex idents (foo.bar) that went through ppx

### DIFF
--- a/process_ocaml/base/ProcessExtra.re
+++ b/process_ocaml/base/ProcessExtra.re
@@ -264,17 +264,27 @@ module F = (Collector: {
 
   let rec addForLongident = (top, path: Path.t, txt: Longident.t, loc) => {
     if (!loc.Location.loc_ghost) {
-      let l = Utils.endOfLocation(loc, String.length(Longident.last(txt)));
-      switch (top) {
-        | Some((t, tip)) => addForPath(path, txt, l, t, tip)
-        | None => addForPathParent(Shared.mapOldPath(path), l)
-      };
-      switch (path, txt) {
-        | (Pdot(pinner, _pname, _), Ldot(inner, name)) => {
-          addForLongident(None, pinner, inner, Utils.chopLocationEnd(loc, String.length(name) + 1));
-        }
-        | (Pident(_), Lident(_)) => ()
-        | _ => ()
+      let idLength = String.length(String.concat(".", Longident.flatten(txt)));
+      let reportedLength = loc.loc_end.pos_cnum - loc.loc_start.pos_cnum;
+      let isPpx = idLength != reportedLength;
+      if (isPpx) {
+        switch (top) {
+          | Some((t, tip)) => addForPath(path, txt, loc, t, tip)
+          | None => addForPathParent(Shared.mapOldPath(path), loc)
+          }
+      } else {
+        let l = Utils.endOfLocation(loc, String.length(Longident.last(txt)));
+        switch (top) {
+          | Some((t, tip)) => addForPath(path, txt, l, t, tip)
+          | None => addForPathParent(Shared.mapOldPath(path), l)
+        };
+        switch (path, txt) {
+          | (Pdot(pinner, _pname, _), Ldot(inner, name)) => {
+            addForLongident(None, pinner, inner, Utils.chopLocationEnd(loc, String.length(name) + 1));
+          }
+          | (Pident(_), Lident(_)) => ()
+          | _ => ()
+        };
       };
     }
   };


### PR DESCRIPTION
Fixes #101.

The PR tries to fix the issue with ReasonReact elements definitions. It does so by adding a special case for locations generated from complex longidents that are being generated by a ppx.

Notes:
- I don't know of any ways to query the AST to know if an ident was added through a ppx 😅  so the method used is to check the length of the ident (as a string) and compare that with the location included in the AST. If it's not the same, then it's supposedly an ident coming from a ppx.
- If it's an ident from a ppx, then the location added that will be added to `extras` is left as is, as any positioning handling that involves the idents from the generated AST will probably not match what the user is seeing on screen.
- In the case the ident comes from a ppx, the locations generated are only for the last segment of the ident, as opposed to the common case where all segments get their locations. For example, for and ident `Foo.make`, only the location for the function `make` would be included in `extras`.

![rls_ppx](https://user-images.githubusercontent.com/220424/59566800-424dc380-9065-11e9-9e36-f2e18be518df.gif)
