### PR TITLE
Add space between number and "more"

### DIFF
--- a/core/CodeLens.re
+++ b/core/CodeLens.re
@@ -7,7 +7,7 @@ let sepList = items =>
     String.concat(", ", Belt.List.take(items, 3) |? [])
     ++ " and "
     ++ string_of_int(List.length(items) - 3)
-    ++ "more";
+    ++ " more";
 
 
 let forOpen = (tracker: SharedTypes.openTracker) => {


### PR DESCRIPTION
Previously you would see something like "a, b, c and 4more". This adds a space between before "more".