### PR TITLE
Add merlin support that doesn't require dune/jbuild

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -65,7 +65,8 @@
 							"dune:opam:/abs/path/to/switch",
 							"bsb-native:4.0.7:js",
 							"bsb-native:4.0.7:bytecode",
-							"bsb-native:4.0.7:native"
+							"bsb-native:4.0.7:native",
+							"merlin:/abs/path/to/project"
 						]
 					},
 					"description": "Only specify this if build system autodetection isn't working for you (for example if you have a bsconfig.json, and a dune file in the same project). The keys in this object should be in uri format, e.g. file:///some/path/here"


### PR DESCRIPTION
This allows RLS to support working on the BuckleScript project directly. I think there's a lot of improvements to be made but this will allow us to use the latest RLS to dev against the bucklescript repo.

Fixes #273 

cc @bobzhang @cristianoc 