### PR TITLE
Fixes unexpected behavior of (**

### DIFF
--- a/editor-extensions/vscode/ocaml.configuration.json
+++ b/editor-extensions/vscode/ocaml.configuration.json
@@ -4,7 +4,7 @@
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": [ "string" ] },
-    { "open": "(**", "close": " *)", "notIn": [ "string" ] }
+    { "open": "(**", "close": " *", "notIn": [ "string" ] }
   ],
   "brackets": [
     [ "{", "}" ],


### PR DESCRIPTION
Related to https://github.com/reasonml-editor/vscode-reasonml/pull/285. Seems that the `vscode-reasonml` is unmaintained. I re pr to there.

Because of the rule `{ "open": "(", "close": ")" }`, the extra parentheses will be appended to the end if we type (**, remove ")" in `"close": "*)"` can solve this problem.