### PR TITLE
Calculate ESY__CACHE_INSTALL_PATH. Fixes failing MacOS CI

### DIFF
--- a/.ci/use-calc-esy-install-path.yml
+++ b/.ci/use-calc-esy-install-path.yml
@@ -1,0 +1,32 @@
+steps:
+  - bash: |
+        # COMPUTE THE ESY INSTALL CACHE LOCATION AHEAD OF TIME
+        DESIRED_LEN="86"
+        # Note: This will need to change when upgrading esy version
+        # that reenables long paths on windows.
+        if [ "$AGENT_OS" == "Windows_NT" ]; then
+        DESIRED_LEN="33"
+        fi
+        HOME_ESY3="$HOME/.esy/3"
+        HOME_ESY3_LEN=${#HOME_ESY3}
+        NUM_UNDERS=$(echo "$(($DESIRED_LEN-$HOME_ESY3_LEN))")
+        UNDERS=$(printf "%-${NUM_UNDERS}s" "_")
+        UNDERS="${UNDERS// /_}"
+        ESY__CACHE_INSTALL_PATH=${HOME_ESY3}${UNDERS}/i
+        if [ "$AGENT_OS" == "Windows_NT" ]; then
+        ESY__CACHE_INSTALL_PATH=$( cygpath --mixed --absolute "$ESY__CACHE_INSTALL_PATH")
+        fi
+        echo "ESY__CACHE_INSTALL_PATH: $ESY__CACHE_INSTALL_PATH"
+        # This will be exposed as an env var ESY__CACHE_INSTALL_PATH, or an
+        # Azure var esy__cache_install_path
+        echo "##vso[task.setvariable variable=esy__cache_install_path]$ESY__CACHE_INSTALL_PATH"
+    displayName: "Task.setvariable ESY__CACHE_INSTALL_PATH"
+    # - bash: |
+    #     which esy
+    #     echo "$( which esy )"
+    #     echo "##vso[task.setvariable variable=esy_bin_location]$(which esy)"
+    #   displayName: "Find esy binary"
+    # - bash: echo ${ESY_BIN_LOCATION}
+    # displayName: "Print esy bin location"
+  - bash: env
+    displayName: "Print environment"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,11 +32,11 @@ jobs:
   variables:
     STAGING_DIRECTORY: /Users/vsts/STAGING
     STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
-    ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i
     ESY__CACHE_SOURCE_TARBALL_PATH: /Users/vsts/.esy/source/i
     # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
+  - template: .ci/use-calc-esy-install-path.yml
   - template: .ci/use-node.yml
   - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml


### PR DESCRIPTION
Bash script inspired by hello-reason (and reason?) repo. Credits: Jordan Walke