### PR TITLE
Add typescript as a syntax dev dependency

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -196,5 +196,8 @@
 		"vscode": "^1.1.17",
 		"vscode-languageclient": "^4.1.3",
 		"vscode-languageserver-types": "^3.14.0"
+	},
+	"devDependencies": {
+		"typescript": "^2.8.1"
 	}
 }


### PR DESCRIPTION
Looks like this isn't a transitive dependency anymore, and it causes the OCaml syntax build to fail if not present.