### PR TITLE
Fix: URI from LSP is decoded properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@opam/ppxlib": "*",
     "@opam/reason": ">= 3.5.0",
     "@opam/stdlib-shims": "*",
+    "@opam/uri": "3.1.0",
     "@reason-native/pastel": "^0.2.2",
     "@reason-native/rely": "^3.1.0",
     "ocaml": "~4.8.1000",

--- a/util/Utils.re
+++ b/util/Utils.re
@@ -130,9 +130,11 @@ let parseWindowsUri = withoutScheme => {
   |> String.concat({|\|})
 };
 
-let parseUri = (uri) =>
-  if (startsWith(uri, "file://")) {
-    let withoutScheme = sliceToEnd(uri, String.length("file://"));
+let parseUri = (uri) => {
+  let withoutPct = Uri.pct_decode(uri);
+  if (startsWith(withoutPct, "file://")) {
+    let withoutScheme = sliceToEnd(withoutPct, String.length("file://"));
+
     if (Sys.os_type == "Unix") {
       Some(withoutScheme)
     } else {
@@ -141,6 +143,7 @@ let parseUri = (uri) =>
   } else {
     None
   };
+}
 
 let locationOffset = (loc, start, length) =>
   Location.{

--- a/util/dune
+++ b/util/dune
@@ -1,7 +1,7 @@
 (library
   (name Util)
   (public_name reason-language-server.Util)
-  (libraries Belt Vendor str)
+  (libraries Belt Vendor str uri)
   (flags :standard -open Vendor -w -9)
   (preprocess (pps Belt_ppx Ppx_monads))
   )


### PR DESCRIPTION
LSP uris are Percent-encoded, so folders like `/esy+cross` are transmitted as `/esy%2Bcross`, this PR fixes it using `@opam/uri`

## Warning
I'm not sure this is the right type of decoding we should be doing, but the behavior can be detected at `vscode-uri` if you try to parse a uri like `file:///esy%2Bcross/esy/esy-package-config/InstallManifest.re`

But as you can see here on [vscode-uri](https://github.com/microsoft/vscode-uri/blob/master/src/index.ts#L719) it uses `decodeURIComponent` which by spec lead to [Decode()](https://www.ecma-international.org/ecma-262/6.0/#sec-decode), which seems a lot like a simple percent encode.