### PR TITLE
Hide lowercase modules (such as local_*) in autocomplete.

### DIFF
--- a/src/analyze/NewCompletions.re
+++ b/src/analyze/NewCompletions.re
@@ -358,7 +358,7 @@ let valueCompletions = (~env: Query.queryEnv, suffix) => {
   Log.log(" - Completing in " ++ env.file.uri);
   let results = [];
   let results =
-    if (suffix == "" || isCapitalized(suffix)) {
+    if (isCapitalized(suffix)) {
       let moduleCompletions = completionForExporteds(
           env.exported.modules, env.file.stamps.modules, suffix, m =>
           Module(m)


### PR DESCRIPTION
I decided to fix #417 myself.

Not sure if this is ok like that, especially if the `isUppercase` fn accounts for everything we want to keep.

But in a quick test with an example-project I did not see the `local_1` anymore, but still saw nested Modules (which are always uppercased).