### PR TITLE
Fix: formattter was removing the trailing line

### DIFF
--- a/src/analyze/AsYouType.re
+++ b/src/analyze/AsYouType.re
@@ -46,7 +46,7 @@ let runRefmt = (~interface, ~moduleName, ~cacheLocation, text, refmt) => {
 let convertToRe = (~formatWidth, ~interface, text, refmt) => {
   let (out, error, success) = Commands.execFull(~input=text, Printf.sprintf("%s --print re --print-width=%d --parse ml%s", Commands.shellEscape(refmt), formatWidth |? 80, interface ? " -i true" : ""));
   if (success) {
-    Ok(String.concat("\n", out))
+    Ok(String.concat("\n", out) ++ "\n")
   } else {
     Error(String.concat("\n", out @ error))
   }
@@ -55,7 +55,7 @@ let convertToRe = (~formatWidth, ~interface, text, refmt) => {
 let format = (text, fmtCmd) => {
   let (out, error, success) = Commands.execFull(~input=text, fmtCmd);
   if (success) {
-    Ok(String.concat("\n", out))
+    Ok(String.concat("\n", out) ++ "\n")
   } else {
     Error(String.concat("\n", out @ error))
   }


### PR DESCRIPTION
## Problem

Currently when we format a Reason file, it removes the trailing new line

## Why does this happen?
As we use [input_line](https://github.com/jaredly/reason-language-server/blob/master/util/Commands.re#L50) to capture the stdout, but input_line removes the \n from the last line and using String.concat doesn't add it back at the end of the list.

## Why this solution?
Modifying the behavior of `Commands.execFull` would imply in some changes on more places and the behavior of execFull seems to be plausible I did just concat \n at the usage site.