### PR TITLE
"Dependencies: -" if there are no dependencies (instead of "Dependenc…

### DIFF
--- a/src/lsp/MessageHandlers.re
+++ b/src/lsp/MessageHandlers.re
@@ -345,10 +345,9 @@ let handlers: list((string, (state, Json.t) => result((state, Json.t), string)))
           CodeLens.forOpens(extra)
         } : lenses;
 
-        let showDependencies = state.settings.dependenciesCodelens;
-        let lenses = showDependencies ? [("Dependencies: " ++ String.concat(", ",
-          List.map(SharedTypes.hashList(extra.externalReferences), fst)
-        ), topLoc), ...lenses] : lenses;
+        let depsList = List.map(SharedTypes.hashList(extra.externalReferences), fst)
+        let depsString = depsList == [] ? "-" : String.concat(", ", depsList)
+        let lenses = (state.settings.dependenciesCodelens==true) ? [("Dependencies: " ++ depsString, topLoc), ...lenses] : lenses;
 
         lenses
       };

--- a/src/lsp/MessageHandlers.re
+++ b/src/lsp/MessageHandlers.re
@@ -346,8 +346,10 @@ let handlers: list((string, (state, Json.t) => result((state, Json.t), string)))
         } : lenses;
 
         let depsList = List.map(SharedTypes.hashList(extra.externalReferences), fst)
-        let depsString = depsList == [] ? "-" : String.concat(", ", depsList)
-        let lenses = (state.settings.dependenciesCodelens==true) ? [("Dependencies: " ++ depsString, topLoc), ...lenses] : lenses;
+        let depsString = depsList == [] ? "[none]" : String.concat(", ", depsList)
+        let lenses = (state.settings.dependenciesCodelens==true) ? 
+          [("Dependencies: " ++ depsString, topLoc), ...lenses] 
+          : lenses;
 
         lenses
       };


### PR DESCRIPTION
feature request issue #437 

adjust the grey colored CodeLens label/information:
 "Dependencies: -" if there are no dependencies (instead of "Dependencies:") 
