### PR TITLE
VSCode extension: Expose function to get current language server client

### DIFF
--- a/editor-extensions/vscode/src/index.js
+++ b/editor-extensions/vscode/src/index.js
@@ -319,5 +319,6 @@ function activate(context) {
     // vscode.commands.registerCommand('reason-language-server.expand_switch', () => {
     // });
 
+    return { getClient: () => client };
 }
 exports.activate = activate;


### PR DESCRIPTION
This will allow other VSCode extensions to pick up and call RLS directly via the already instantiated language server client.

Context is I'm experimenting a lot with using the output from hovers etc from RLS to drive other functionality in other extensions. This would let me do that "natively".

This would only require a new VSCode extension release.