### PR TITLE
Second attempt to fix #417 (and fix #458 too)

### DIFF
--- a/src/analyze/NewCompletions.re
+++ b/src/analyze/NewCompletions.re
@@ -359,6 +359,10 @@ let valueCompletions = (~env: Query.queryEnv, suffix) => {
   let results = [];
   let results =
     if (suffix == "" || isCapitalized(suffix)) {
+
+      // Get rid of lowercase modules (#417)
+      env.exported.modules |> Hashtbl.filter_map_inplace((name, key) => isCapitalized(name) ? Some(key) : None);
+
       let moduleCompletions = completionForExporteds(
           env.exported.modules, env.file.stamps.modules, suffix, m =>
           Module(m)

--- a/src/analyze/NewCompletions.re
+++ b/src/analyze/NewCompletions.re
@@ -358,7 +358,7 @@ let valueCompletions = (~env: Query.queryEnv, suffix) => {
   Log.log(" - Completing in " ++ env.file.uri);
   let results = [];
   let results =
-    if (isCapitalized(suffix)) {
+    if (suffix == "" || isCapitalized(suffix)) {
       let moduleCompletions = completionForExporteds(
           env.exported.modules, env.file.stamps.modules, suffix, m =>
           Module(m)


### PR DESCRIPTION
This is another attempt to fix #417. I introduced a regression with my first attempt (#418) which is documented in #458

Although I am still not sure, whether this is the most efficient place to do this, both issues are hereby gone. There is no weird "local_1" variable visible in the auto-complete AND the auto-complete shows (capitalized) modules again.