### PR TITLE
remove rescript syntax from client

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -154,11 +154,6 @@
 				"embeddedLanguages": {
 					"meta.embedded.block.reason": "reason"
 				}
-			},
-			{
-				"language": "bucklescript",
-				"scopeName": "source.bucklescript",
-				"path": "./bucklescript.json"
 			}
 		],
 		"languages": [
@@ -194,17 +189,6 @@
 					".reli"
 				],
 				"configuration": "./reason-lisp.configuration.json"
-			},
-			{
-				"id": "bucklescript",
-				"aliases": [
-					"BuckleScript"
-				],
-				"extensions": [
-					".res",
-					".resi"
-				],
-				"configuration": "./bucklescript.configuration.json"
 			}
 		]
 	},


### PR DESCRIPTION
#467 was made to remove support for .res/.resi files but since it was still present in the client, it still has prevalence over rescript-vscode.
Thanks to this change it should really be removed.