### PR TITLE
Add support for odoc comment syntax for ReasonML comments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,6 +131,7 @@ The language server supports the following settings (not all of them apply to al
 - `dependencies_codelens` - list a files dependencies at the top (bool)
 - `opens_codelens` - show what values are used from an `open` (bool)
 - `autoRebuild` — rebuild project on save (turned on by default) (bool)
+- `use_odoc_for_reason` - treat ReasonML comments as odoc comments (turned off by default) 
 
 ### Debug settings
 

--- a/editor-extensions/coc.nvim/package.json
+++ b/editor-extensions/coc.nvim/package.json
@@ -97,6 +97,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enables autorun of bsb"
+        },
+        "reason_language_server.use_odoc_for_reason": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables odoc syntax for ReasonML comments"
         }
       }
     }

--- a/editor-extensions/vscode/Readme.md
+++ b/editor-extensions/vscode/Readme.md
@@ -32,6 +32,7 @@ all configuration is prefixed with `reason_language_server.`
 - `.dependencies_codelens` - list a files dependencies at the top
 - `.opens_codelens` - show what values are used from an `open`
 - `.autoRebuild` — rebuild project on save (turned on by default)
+- `.use_odoc_for_reason` - treat ReasonML comments as odoc comments (turned off by default) 
 
 ## Debugging configuration
 most useful if your developing the language server

--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -126,6 +126,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enables autorun of bsb"
+				},
+				"reason_language_server.use_odoc_for_reason": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enables odoc syntax for ReasonML comments"
 				}
 			}
 		},

--- a/src/analyze/AsYouType.re
+++ b/src/analyze/AsYouType.re
@@ -171,7 +171,7 @@ let getAst = (~cacheLocation, ~compilerVersion, ~moduleName, ~uri) => {
   Ok("NVM")
 }; */
 
-let process = (~uri, ~moduleName, ~basePath, ~reasonFormat, text, ~cacheLocation, ~compilerVersion, ~allLocations, compilerPath, refmtPath, includes, flags) => {
+let process = (~uri, ~moduleName, ~basePath, ~reasonFormat, text, ~cacheLocation, ~compilerVersion, ~allLocations, compilerPath, refmtPath, includes, flags, converter) => {
   let interface = Utils.endsWith(uri, "i");
   let%try (syntaxError, astFile) = switch (refmtPath) {
     | Some(refmtPath) => runRefmt(~interface, ~moduleName, ~cacheLocation, text, refmtPath);
@@ -199,7 +199,7 @@ let process = (~uri, ~moduleName, ~basePath, ~reasonFormat, text, ~cacheLocation
         | Some({Unix.st_size: size}) => Log.log("Size " ++ string_of_int(size))
         | _ => Log.log("Doesn't exist")
         };
-        let%try_wrap {file, extra} = fullForCmt(cmtPath, uri, x => x);
+        let%try_wrap {file, extra} = fullForCmt(cmtPath, uri, converter);
         let errorText = String.concat("\n", lines);
         switch (syntaxError) {
           | Some(s) =>
@@ -227,7 +227,7 @@ let process = (~uri, ~moduleName, ~basePath, ~reasonFormat, text, ~cacheLocation
       // close_in(ic);
       // | _ => Log.log("Doesn't exist")
       // };
-      let%try_wrap full = fullForCmt(cmtPath, uri, x => x);
+      let%try_wrap full = fullForCmt(cmtPath, uri, converter);
       Success(String.concat("\n", lines @ error), full)
     }
   }

--- a/src/analyze/TopTypes.re
+++ b/src/analyze/TopTypes.re
@@ -48,7 +48,8 @@ type settings = {
   showModulePathOnHover: bool,
   recordAllLocations: bool,
   autoRebuild: bool,
-  buildSystemOverrideByRoot: list((string, BuildSystem.t))
+  buildSystemOverrideByRoot: list((string, BuildSystem.t)),
+  useOdocForReason: bool
 };
 
 type state = {
@@ -96,6 +97,7 @@ let empty = () => {
     recordAllLocations: false,
     autoRebuild: true,
     buildSystemOverrideByRoot: [],
+    useOdocForReason: false,
   },
 };
 

--- a/src/analyze_fixture_tests/lib/TestUtils.re
+++ b/src/analyze_fixture_tests/lib/TestUtils.re
@@ -115,6 +115,7 @@ let getState = () => {
       opensCodelens: true,
       dependenciesCodelens: true,
       clientNeedsPlainText: false,
+      useOdocForReason: false,
       showModulePathOnHover: false,
       recordAllLocations: false,
       autoRebuild: false,

--- a/src/analyze_fixture_tests/lib/TestUtils.re
+++ b/src/analyze_fixture_tests/lib/TestUtils.re
@@ -182,7 +182,8 @@ let setUp = (~projectDir, files, text) => {
       package.compilerPath,
       package.refmtPath,
       [tmp],
-      ""
+      "",
+      x => x
     );
     switch result {
       | AsYouType.SyntaxError(text, _, _) => failwith("Syntax error " ++ text)
@@ -212,7 +213,8 @@ let setUp = (~projectDir, files, text) => {
     package.compilerPath,
     package.refmtPath,
     [tmp],
-    ""
+    "",
+    x => x
   );
   /* switch result {
     | AsYouType.SyntaxError(syntaxError, _, full) => Log.log("Syntax error! " ++ syntaxError)

--- a/src/lsp/NotificationHandlers.re
+++ b/src/lsp/NotificationHandlers.re
@@ -110,6 +110,7 @@ let notificationHandlers: list((string, (state, Json.t) => result(state, string)
     let crossFileAsYouType = false;
     let showModulePathOnHover = (settings |?> Json.get("show_module_path_on_hover") |?> Json.bool) |? true;
     let autoRebuild = settings |?> Json.get("autoRebuild") |?> Json.bool |? true;
+    let useOdocForReason = (settings |?> Json.get("use_odoc_for_reason") |?> Json.bool) |? false;
 
     let buildSystemOverrideByRoot = (settings |?> Json.get("build_system_override_by_root") |?> Json.obj |? [])->Belt.List.keepMap(((key, v)) => {
       let%opt v = Json.string(v);
@@ -132,6 +133,7 @@ let notificationHandlers: list((string, (state, Json.t) => result(state, string)
         showModulePathOnHover,
         autoRebuild,
         buildSystemOverrideByRoot,
+        useOdocForReason
       },
     });
   }),


### PR DESCRIPTION
This PR adds support for the `odoc` comment syntax for `ReasonML` documentation comments. The support is disabled by default but can be enabled using the `use_odoc_for_reason` configuration.