### PR TITLE
Fix unhandled EPIPE error leading to language server crashes

### DIFF
--- a/src/lsp/Main.re
+++ b/src/lsp/Main.re
@@ -301,6 +301,7 @@ let showHelp = () => {
 };
 
 let main = () => {
+  Sys.set_signal(Sys.sigpipe, Sys.Signal_ignore);
   switch (parseArgs(Sys.argv->Belt.List.fromArray)) {
     | (opts, _) when opts->hasOpts(["-h", "--help"]) => showHelp();
     | (opts, []) =>

--- a/util/Commands.re
+++ b/util/Commands.re
@@ -34,7 +34,7 @@ let execFull = (~input=?, ~pwd=?, ~env=Unix.environment(), cmd) => {
   | None => ()
   | Some(text) => output_string(cmd_in, text)
   };
-  close_out(cmd_in);
+  close_out_noerr(cmd_in);
 
   let cmd_out_descr = Unix.descr_of_in_channel(cmd_out);
   let cmd_err_descr = Unix.descr_of_in_channel(cmd_err);


### PR DESCRIPTION
The default behaviour of ocaml when receiving a `SIGPIPE` signal is to terminate the program. Processes opened in `Commands.re` it can  exit prematurely causing an `EPIPE` error which triggers the `SIGPIPE` signal leading the language server process to terminate. To circumvent that we tell OCaml to ignore `SIGPIPE` s.t. the error can be handled when interacting with the channels/file-descriptors in `Commands`.